### PR TITLE
Upgrade to CafeLib version 2.0.2

### DIFF
--- a/Core/CafeLib.Core.Buffers/ByteSequenceSegment.cs
+++ b/Core/CafeLib.Core.Buffers/ByteSequenceSegment.cs
@@ -44,8 +44,9 @@ namespace CafeLib.Core.Buffers
             while (Next != null) 
                 last = last?.Next as ByteSequenceSegment;
 
-            // ReSharper disable once PossibleNullReferenceException
-            return new ReadOnlySequence<byte>(this, 0, last, last.Memory.Length - 1);
+            return last != null 
+                ? new ReadOnlySequence<byte>(this, 0, last, last.Memory.Length - 1) 
+                : ReadOnlySequence<byte>.Empty;
         }
     }
 }

--- a/Core/CafeLib.Core.Buffers/ByteSpan.cs
+++ b/Core/CafeLib.Core.Buffers/ByteSpan.cs
@@ -84,5 +84,23 @@ namespace CafeLib.Core.Buffers
 
         public static implicit operator ByteSpan(ReadOnlyByteSequence rhs) => new(rhs.Data.ToArray());
         public static implicit operator ReadOnlyByteSequence(ByteSpan rhs) => new(rhs);
+
+        public static ByteSpan operator +(ByteSpan span1, ByteSpan span2)
+        {
+            return Concat(span1, span2);
+        }
+
+        public static ByteSpan operator +(ByteSpan span1, ReadOnlyByteSpan span2)
+        {
+            return Concat(span1, span2.Data);
+        }
+
+        public static ByteSpan Concat(ByteSpan span1, ByteSpan span2)
+        {
+            var span = new ByteSpan(new byte[span1.Length + span2.Length]);
+            span1.CopyTo(span);
+            span2.CopyTo(span[span1.Length..]);
+            return span;
+        }
     }
 }

--- a/Core/CafeLib.Core.Buffers/CharSpan.cs
+++ b/Core/CafeLib.Core.Buffers/CharSpan.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Reflection;
+using System.Buffers;
 using System.Runtime.CompilerServices;
 
 namespace CafeLib.Core.Buffers
@@ -44,6 +44,7 @@ namespace CafeLib.Core.Buffers
         public CharSpan Slice(int start, int length) => Data.Slice(start, length);
 
         public char[] ToArray() => Data.ToArray();
+        public override string ToString() => Data.ToString();
 
         public Enumerator GetEnumerator() => new(this);
 
@@ -73,8 +74,6 @@ namespace CafeLib.Core.Buffers
             return destination;
         }
 
-        public override string ToString() => Data.ToString();
-
         public static CharSpan Empty => new();
 
         public static implicit operator CharSpan(char[] rhs) => new(rhs);
@@ -87,6 +86,27 @@ namespace CafeLib.Core.Buffers
         public static implicit operator ReadOnlySpan<char>(CharSpan rhs) => rhs.Data;
 
         public static implicit operator CharSpan(ReadOnlyCharSpan rhs) => new(rhs.ToArray());
-        public static implicit operator ReadOnlyCharSpan(CharSpan rhs) => rhs.Data;
+        public static implicit operator ReadOnlyCharSpan(CharSpan rhs) => new(rhs.Data);
+
+        public static implicit operator string(CharSpan rhs) => rhs.Data.ToString();
+        public static implicit operator CharSpan(string rhs) => new(rhs);
+
+        public static CharSpan operator +(CharSpan span1, CharSpan span2)
+        {
+            return Concat(span1, span2);
+        }
+
+        public static CharSpan operator +(CharSpan span1, ReadOnlyCharSpan span2)
+        {
+            return Concat(span1, span2.Data);
+        }
+
+        public static CharSpan Concat(CharSpan span1, CharSpan span2)
+        {
+            var span = new CharSpan(new char[span1.Length + span2.Length]);
+            span1.CopyTo(span);
+            span2.CopyTo(span[span1.Length..]);
+            return span;
+        }
     }
 }

--- a/Core/CafeLib.Core.Buffers/ReadOnlyByteMemory.cs
+++ b/Core/CafeLib.Core.Buffers/ReadOnlyByteMemory.cs
@@ -43,7 +43,7 @@ namespace CafeLib.Core.Buffers
         public int Length => Data.Length;
 
         public ReadOnlyByteSpan Slice(int start) => Data.Span[start..];
-        public ReadOnlyByteSpan Slice(int start, int length) => Data.Span.Slice(start, length);
+        public ReadOnlyByteSpan Slice(int start, int length) => Data.Span[start..(start + length)];
 
         public void CopyTo(ByteMemory destination) => Data.CopyTo(destination);
         public byte[] ToArray() => Data.ToArray();

--- a/Core/CafeLib.Core.Buffers/ReadOnlyByteSpan.cs
+++ b/Core/CafeLib.Core.Buffers/ReadOnlyByteSpan.cs
@@ -17,7 +17,6 @@ namespace CafeLib.Core.Buffers
         {
         }
 
-
         public ReadOnlyByteSpan(ReadOnlyByteSequence data)
         {
             Data = data.ToSpan();
@@ -66,15 +65,26 @@ namespace CafeLib.Core.Buffers
 
         public static ReadOnlyByteSpan Empty => default;
 
-        public static implicit operator ByteSpan(ReadOnlyByteSpan rhs) => rhs.Data;
-
         public static implicit operator ReadOnlySpan<byte>(ReadOnlyByteSpan rhs) => rhs.Data;
-        public static implicit operator ReadOnlyByteSpan(ReadOnlySpan<byte> rhs) => new ReadOnlyByteSpan(                                                                                                                                                                                                                                    rhs);
+        public static implicit operator ReadOnlyByteSpan(ReadOnlySpan<byte> rhs) => new(rhs);
 
         public static implicit operator Span<byte>(ReadOnlyByteSpan rhs) => new(rhs.Data.ToArray());
         public static implicit operator ReadOnlyByteSpan(Span<byte> rhs) => new(rhs);
 
         public static implicit operator byte[](ReadOnlyByteSpan rhs) => rhs.Data.ToArray();
         public static implicit operator ReadOnlyByteSpan(byte[] rhs) => new(rhs);
+
+        public static ReadOnlyByteSpan operator +(ReadOnlyByteSpan span1, ByteSpan span2)
+        {
+            return ByteSpan.Concat(span1, span2);
+        }
+
+        public static ReadOnlyByteSpan operator +(ReadOnlyByteSpan span1, ReadOnlyByteSpan span2)
+        {
+            var span = new ByteSpan(new byte[span1.Length + span2.Length]);
+            span1.CopyTo(span);
+            span2.CopyTo(span[span1.Length..]);
+            return span;
+        }
     }
 }

--- a/Core/CafeLib.Core.Buffers/ReadOnlyCharSpan.cs
+++ b/Core/CafeLib.Core.Buffers/ReadOnlyCharSpan.cs
@@ -24,6 +24,7 @@ namespace CafeLib.Core.Buffers
         public ReadOnlyCharSpan Slice(int start, int length) => Data[start..(start+length)];
 
         public char[] ToArray() => Data.ToArray();
+        public override string ToString() => Data.ToString();
 
         public CharSpan CopyTo(CharSpan destination)
         {
@@ -33,7 +34,7 @@ namespace CafeLib.Core.Buffers
 
         public int SequenceCompareTo(ReadOnlyCharSpan target) => Data.SequenceCompareTo(target);
 
-        public Enumerator GetEnumerator() => new Enumerator(this);
+        public Enumerator GetEnumerator() => new(this);
 
         public ref struct Enumerator
         {
@@ -61,15 +62,25 @@ namespace CafeLib.Core.Buffers
         public static ReadOnlyCharSpan Empty => default;
 
         public static implicit operator ReadOnlySpan<char>(ReadOnlyCharSpan rhs) => rhs.Data;
-        public static implicit operator ReadOnlyCharSpan(ReadOnlySpan<char> rhs) => new ReadOnlyCharSpan(rhs);
-
-        public static implicit operator CharSpan(ReadOnlyCharSpan rhs) => rhs.Data;
-        public static implicit operator ReadOnlyCharSpan(Span<char> rhs) => new ReadOnlyCharSpan(rhs);
+        public static implicit operator ReadOnlyCharSpan(ReadOnlySpan<char> rhs) => new(rhs);
 
         public static implicit operator char[](ReadOnlyCharSpan rhs) => rhs.Data.ToArray();
-        public static implicit operator ReadOnlyCharSpan(char[] rhs) => new ReadOnlyCharSpan(rhs);
+        public static implicit operator ReadOnlyCharSpan(char[] rhs) => new(rhs);
         
         public static implicit operator string(ReadOnlyCharSpan rhs) => rhs.Data.ToString();
-        public static implicit operator ReadOnlyCharSpan(string rhs) => new ReadOnlyCharSpan(rhs);
+        public static implicit operator ReadOnlyCharSpan(string rhs) => new(rhs);
+
+        public static ReadOnlyCharSpan operator +(ReadOnlyCharSpan span1, ReadOnlyCharSpan span2)
+        {
+            var span = new CharSpan(new char[span1.Length + span2.Length]);
+            span1.CopyTo(span);
+            span2.CopyTo(span[span1.Length..]);
+            return span;
+        }
+
+        public static ReadOnlyCharSpan operator +(ReadOnlyCharSpan span1, CharSpan span2)
+        {
+            return CharSpan.Concat(span1, span2.Data);
+        }
     }
 }

--- a/Core/CafeLib.Core.Buffers/UInt32Span.cs
+++ b/Core/CafeLib.Core.Buffers/UInt32Span.cs
@@ -2,7 +2,7 @@
 
 namespace CafeLib.Core.Buffers
 {
-    public ref struct UInt32Span
+    public readonly ref struct UInt32Span
     {
         public Span<uint> Data { get; }
 

--- a/Core/CafeLib.Core.Buffers/UInt64Span.cs
+++ b/Core/CafeLib.Core.Buffers/UInt64Span.cs
@@ -2,7 +2,7 @@
 
 namespace CafeLib.Core.Buffers
 {
-    public ref struct UInt64Span
+    public readonly ref struct UInt64Span
     {
         public Span<ulong> Data { get; }
 

--- a/Core/CafeLib.Core.Numerics/UInt256.cs
+++ b/Core/CafeLib.Core.Numerics/UInt256.cs
@@ -10,7 +10,8 @@ namespace CafeLib.Core.Numerics
         private ulong _n2 = 0;
         private ulong _n3 = 0;
 
-        public const int Length = 4 * sizeof(ulong);
+        public const int Width = 4;
+        public const int Length = Width * sizeof(ulong);
 
         public static UInt256 Zero { get; } = new(0);
         public static UInt256 One { get; } = new(1);
@@ -140,13 +141,13 @@ namespace CafeLib.Core.Numerics
         public static explicit operator UInt256(byte[] rhs) => new(rhs);
         public static implicit operator byte[](UInt256 rhs) => rhs.Span.ToArray();
 
-        public static implicit operator int(UInt256 rhs) => (int)rhs._n0;
+        public static explicit operator int(UInt256 rhs) => (int)rhs._n0;
         public static implicit operator UInt256(int rhs) => new((ulong)rhs, 0, 0, 0);
-        public static implicit operator uint(UInt256 rhs) => (uint)rhs._n0;
+        public static explicit operator uint(UInt256 rhs) => (uint)rhs._n0;
         public static implicit operator UInt256(uint rhs) => new(rhs, 0, 0, 0);
-        public static implicit operator long(UInt256 rhs) => (long)rhs._n0;
+        public static explicit operator long(UInt256 rhs) => (long)rhs._n0;
         public static implicit operator UInt256(long rhs) => new((ulong)rhs, 0, 0, 0);
-        public static implicit operator ulong(UInt256 rhs) => rhs._n0;
+        public static explicit operator ulong(UInt256 rhs) => rhs._n0;
         public static implicit operator UInt256(ulong rhs) => new(rhs, 0, 0, 0);
 
         public static explicit operator UInt256(ByteSpan rhs) => new(rhs);
@@ -166,18 +167,17 @@ namespace CafeLib.Core.Numerics
 
         public static UInt256 operator <<(UInt256 a, int shift)
         {
-            const int width = 4;
             var r = Zero;
             var rpn = r.Span64.Data;
             var apn = a.Span64.Data;
             var k = shift / 64;
             shift %= 64;
-            for (var i = 0; i < width; i++)
+            for (var i = 0; i < Width; i++)
             {
-                if (i + k + 1 < width && shift != 0)
+                if (i + k + 1 < Width && shift != 0)
                     rpn[i + k + 1] |= (apn[i] >> (64 - shift));
 
-                if (i + k < width)
+                if (i + k < Width)
                     rpn[i + k] |= (apn[i] << shift);
             }
             return r;
@@ -185,13 +185,12 @@ namespace CafeLib.Core.Numerics
 
         public static UInt256 operator >>(UInt256 a, int shift)
         {
-            const int width = 4;
             var r = Zero;
             var rpn = r.Span64.Data;
             var apn = a.Span64.Data;
             var k = shift / 64;
             shift %= 64;
-            for (var i = 0; i < width; i++)
+            for (var i = 0; i < Width; i++)
             {
                 if (i - k - 1 >= 0 && shift != 0)
                     rpn[i - k - 1] |= (apn[i] << (64 - shift));
@@ -234,10 +233,9 @@ namespace CafeLib.Core.Numerics
 
         public static UInt256 operator ++(UInt256 a)
         {
-            const int width = 4;
             var apn = a.Span64;
-            int i = 0;
-            while (++apn[i] == 0 && i < width - 1)
+            var i = 0;
+            while (++apn[i] == 0 && i < Width - 1)
                 i++;
             return a;
         }
@@ -246,13 +244,13 @@ namespace CafeLib.Core.Numerics
         public static UInt256 operator +(UInt256 a, ulong b) => a + new UInt256(b);
         public static UInt256 operator +(UInt256 a, UInt256 b)
         {
-            const int width = 8;
+            const int size = 2*Width;
             ulong carry = 0;
             var r = Zero;
             var rpn = r.Span32;
             var apn = a.Span32;
             var bpn = b.Span32;
-            for (int i = 0; i < width; i++)
+            for (int i = 0; i < size; i++)
             {
                 ulong n = carry + apn[i] + bpn[i];
                 rpn[i] = (uint)(n & 0xffffffff);
@@ -263,24 +261,33 @@ namespace CafeLib.Core.Numerics
 
         public static UInt256 operator -(UInt256 a)
         {
-            const int width = 4;
             var r = Zero;
             var rpn = r.Span64;
             var apn = a.Span64;
-            for (int i = 0; i < width; i++)
+            for (int i = 0; i < Width; i++)
                 rpn[i] = ~apn[i];
             r++;
             return r;
         }
 
-        public static UInt256 operator |(UInt256 a, UInt256 b)
+        public static UInt256 operator &(UInt256 a, UInt256 b)
         {
-            const int width = 4;
             var r = Zero;
             var rpn = r.Span64;
             var apn = a.Span64;
             var bpn = b.Span64;
-            for (int i = 0; i < width; i++)
+            for (int i = 0; i < Width; i++)
+                rpn[i] = apn[i] & bpn[i];
+            return r;
+        }
+
+        public static UInt256 operator |(UInt256 a, UInt256 b)
+        {
+            var r = Zero;
+            var rpn = r.Span64;
+            var apn = a.Span64;
+            var bpn = b.Span64;
+            for (int i = 0; i < Width; i++)
                 rpn[i] = apn[i] | bpn[i];
             return r;
         }

--- a/Core/CafeLib.Core.UnitTests/BufferTests.cs
+++ b/Core/CafeLib.Core.UnitTests/BufferTests.cs
@@ -9,6 +9,38 @@ namespace CafeLib.Core.UnitTests;
 public class BufferTests
 {
     [Fact]
+    public void ByteSpan_Concat_Test()
+    {
+        var encoder = new AsciiEncoder();
+        var span1 = new ByteSpan(encoder.Decode("cat"));
+        var span2 = new ByteSpan(encoder.Decode("doggy"));
+        var concat = span1 + span2;
+        var result = encoder.Encode(concat);
+        Assert.Equal("catdoggy", result);
+
+        var span3 = new ReadOnlyByteSpan(encoder.Decode("doggy"));
+        concat = span1 + span3;
+        result = encoder.Encode(concat);
+        Assert.Equal("catdoggy", result);
+    }
+
+    [Fact]
+    public void ReadOnlyByteSpan_Concat_Test()
+    {
+        var encoder = new AsciiEncoder();
+        var span1 = new ReadOnlyByteSpan(encoder.Decode("cat"));
+        var span2 = new ReadOnlyByteSpan(encoder.Decode("doggy"));
+        var concat = span1 + span2;
+        var result = encoder.Encode(concat);
+        Assert.Equal("catdoggy", result);
+
+        var span3 = new ByteSpan(encoder.Decode("doggy"));
+        concat = span1 + span3;
+        result = encoder.Encode(concat);
+        Assert.Equal("catdoggy", result);
+    }
+
+    [Fact]
     public void ReadOnlyByteSpan_Slice_Test()
     {
         const string text = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -60,6 +92,19 @@ public class BufferTests
     }
 
     [Fact]
+    public void CharSpan_Concat_Test()
+    {
+        var span1 = new CharSpan("cat");
+        var span2 = new CharSpan("doggy");
+        var result = span1 + span2;
+        Assert.Equal("catdoggy", result.ToString());
+
+        var span3 = new ReadOnlyCharSpan("doggy");
+        result = span1 + span3;
+        Assert.Equal("catdoggy", result.ToString());
+   }
+
+    [Fact]
     public void CharSpan_Slice_Test()
     {
         const string text = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -68,6 +113,19 @@ public class BufferTests
         var etojSlice = charSpan.Slice(4, 6);
         var charsSlice = charSpan[4..10];
         Assert.Equal(charsSlice.ToString(), etojSlice.ToString());
+    }
+
+    [Fact]
+    public void ReadOnlyCharSpan_Concat_Test()
+    {
+        var span1 = new ReadOnlyCharSpan("cat");
+        var span2 = new ReadOnlyCharSpan("doggy");
+        var result = span1 + span2;
+        Assert.Equal("catdoggy", result.ToString());
+
+        var span3 = new CharSpan("doggy");
+        result = span1 + span3;
+        Assert.Equal("catdoggy", result);
     }
 
     [Fact]

--- a/Core/CafeLib.Core.UnitTests/NumericsTests.cs
+++ b/Core/CafeLib.Core.UnitTests/NumericsTests.cs
@@ -269,6 +269,24 @@ namespace CafeLib.Core.UnitTests
             Assert.Equal(hexReverseExpected, hex.StartsWith("0x") ? $"0x{uint256.ToHex(false)}" : $"{uint256.ToHex(false)}");
         }
 
+        [Fact]
+        public void UInt256_Operator_BinaryAnd_Test()
+        {
+            var source = UInt256.FromHex("0000001c3fffc000000000000000000000000000000000000000000000000000");
+            var mask = UInt256.FromHex("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+            var result = UInt256.FromHex("000000003fffc000000000000000000000000000000000000000000000000000");
+            var target = source & mask;
+            Assert.Equal(result, target);
+        }
+
+        [Fact]
+        public void UInt256_Operator_BinaryOr_Test()
+        {
+            var source = UInt256.FromHex("0000001c3fffc000000000000000000000000000000000000000000000000000");
+            var target = source | UInt256.Zero;
+            Assert.Equal(source, target);
+        }
+
         #endregion
 
         #region UInt512 Tests

--- a/Samples/Network/SignalR/SignalRChannelTest/SignalRChannelTest/SignalRChannelTest.csproj
+++ b/Samples/Network/SignalR/SignalRChannelTest/SignalRChannelTest/SignalRChannelTest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-	<Version Condition=" '$(Version)' == '' ">2.0.1</Version>
+	<Version Condition=" '$(Version)' == '' ">2.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Network/SignalR/SignalRCoreApp/SignalRCoreApp/SignalRCoreApp.csproj
+++ b/Samples/Network/SignalR/SignalRCoreApp/SignalRCoreApp/SignalRCoreApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-	<Version Condition=" '$(Version)' == '' ">2.0.1</Version>
+	<Version Condition=" '$(Version)' == '' ">2.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/Network/WebSockets/WebSocketChatServer/WebSocketChatServer.csproj
+++ b/Samples/Network/WebSockets/WebSocketChatServer/WebSocketChatServer.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CafeLib.AspNet.WebSockets" Version="1.6.0" />
+    <PackageReference Include="CafeLib.AspNet.WebSockets" Version="2.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Samples/Network/WebSockets/WebSocketConsoleClient/WebSocketConsoleClient.csproj
+++ b/Samples/Network/WebSockets/WebSocketConsoleClient/WebSocketConsoleClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/build.cake
+++ b/build.cake
@@ -12,12 +12,12 @@ vars.root = GetCurrentDirectory();
 // Setup CafeLib components (name, version).
 public static readonly IDictionary<string, string> Components = new Dictionary<string, string>
 {
-    {"Core", "2.0.1"},
-    {"Cryptography", "2.0.1"},
-    {"Data", "2.0.1"},
-    {"Authorization", "2.0.1"},
-    {"Network", "2.0.1"},
-    {"Blazor", "2.0.1"}
+    {"Core", "2.0.2"},
+    {"Cryptography", "2.0.2"},
+    {"Data", "2.0.2"},
+    {"Authorization", "2.0.2"},
+    {"Network", "2.0.2"},
+    {"Blazor", "2.0.2"}
 };
 
 // Get arguments.


### PR DESCRIPTION
Added Concat operator to ByteSpan, ReadOnlyByteSpan, CharSpan, ReadOnlyCharSpan.
Added Logical And operator to UInt256.
Modified UInt256 native value type casts from implicit to explicit.
Changed UInt32Span & UInt64Span to readonly ref struct.
